### PR TITLE
Take port into account in stubs

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -18,6 +18,28 @@ describe WebMock do
     end
   end
 
+  it "stubs http request with url (example with port)" do
+    WebMock.wrap do
+      WebMock.stub :any, "http://www.example.com:8080"
+
+      response = HTTP::Client.get "http://www.example.com:8080"
+      response.status_code.should eq(200)
+      response.body.should eq("")
+      response.headers["Content-length"].should eq("0")
+    end
+  end
+
+  it "stubs http request with url (example with default port)" do
+    WebMock.wrap do
+      WebMock.stub :any, "http://www.example.com"
+
+      response = HTTP::Client.get "http://www.example.com:80"
+      response.status_code.should eq(200)
+      response.body.should eq("")
+      response.headers["Content-length"].should eq("0")
+    end
+  end
+
   it "stubs http request with uri" do
     WebMock.wrap do
       WebMock.stub :any, "www.example.com"
@@ -39,6 +61,26 @@ describe WebMock do
   it "doesn't find stub and raises" do
     expect_no_match do
       HTTP::Client.get "http://www.example.com"
+    end
+  end
+
+  it "doesn't find stub because host doesn't match" do
+    WebMock.wrap do
+      WebMock.stub :get, "www.crystal.com/foo"
+
+      expect_no_match do
+        HTTP::Client.get "http://www.example.com/foo"
+      end
+    end
+  end
+
+  it "doesn't find stub because port doesn't match" do
+    WebMock.wrap do
+      WebMock.stub :get, "www.example.com:8080/foo"
+
+      expect_no_match do
+        HTTP::Client.get "http://www.example.com/foo"
+      end
     end
   end
 

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -1,7 +1,6 @@
 class WebMock::Stub
   def initialize(@method, uri)
-    @uri = URI.parse(uri)
-    @uri = URI.parse("http://#{uri}") unless @uri.host
+    @uri = parse_uri(uri)
 
     # For to_return
     @status = 200
@@ -39,15 +38,15 @@ class WebMock::Stub
   end
 
   def matches_host?(request)
-    host = request.headers["Host"]
-    host == @uri.host
+    host_uri = parse_uri(request.headers["Host"])
+    host_uri.host == @uri.host && host_uri.port == @uri.port
   end
 
   def matches_path?(request)
     uri_path = @uri.path || "/"
     uri_query = @uri.query
 
-    request_uri = URI.parse("http://example.com#{request.path}")
+    request_uri = parse_uri("http://example.com#{request.path}")
     request_path = request_uri.path
     request_query = request_uri.query
 
@@ -80,5 +79,11 @@ class WebMock::Stub
 
   def exec
     HTTP::Response.new(@status, body: @body, headers: @headers)
+  end
+
+  private def parse_uri(uri_string)
+    uri = URI.parse(uri_string)
+    uri = URI.parse("http://#{uri_string}") unless uri.host
+    uri
   end
 end


### PR DESCRIPTION
Port was simply being ignored on stubs, with the two following bad consequences:
- Stub on `:8080`, request to `:8080`: it should match, but didn't
- Stub on `:8080`, request to `:80`: it shouldn't match, but did

With this PR, port is taken into account in host checks.
