### PR TITLE
Crystal 0.11.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/manastech/webmock.cr.svg?branch=master)](https://travis-ci.org/manastech/webmock.cr)
 
-Library for stubbing `HTTP::Client` requests in [Crystal](http://crystal-lang.org/). Current version requires Crystal 0.8.0.
+Library for stubbing `HTTP::Client` requests in [Crystal](http://crystal-lang.org/). Current version requires Crystal 0.11.0.
 
 Inspired by [webmock ruby gem](https://github.com/bblimke/webmock).
 

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -9,7 +9,7 @@ class HTTP::Client
       request.headers["User-agent"] ||= "Crystal"
       request.to_io(socket)
       socket.flush
-      HTTP::Response.from_io(socket, request.ignore_body?).tap do |response|
+      HTTP::Client::Response.from_io(socket, request.ignore_body?).tap do |response|
         close unless response.keep_alive?
       end
     else

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -79,7 +79,7 @@ class WebMock::Stub
   end
 
   def exec
-    HTTP::Response.new(@status, body: @body, headers: @headers)
+    HTTP::Client::Response.new(@status, body: @body, headers: @headers)
   end
 
   private def parse_uri(uri_string)


### PR DESCRIPTION
Adjust `webmock` to support breaking changes in 0.11.0: `HTTP::Response` -> `HTTP::Client::Response`
