### PR TITLE
Count number of calls for each stub

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -279,6 +279,37 @@ describe WebMock do
     end
   end
 
+  describe ".calls" do
+    it "returns 0 by default" do
+      WebMock.wrap do
+        stub = WebMock.stub :get, "www.crystal.com/foo"
+        stub.calls.should eq(0)
+      end
+    end
+
+    it "increments by one" do
+      WebMock.wrap do
+        stub = WebMock.stub :get, "www.crystal.com/foo"
+
+        HTTP::Client.get "http://www.crystal.com/foo"
+
+        stub.calls.should eq(1)
+      end
+    end
+
+    it "increments multiple times" do
+      WebMock.wrap do
+        stub = WebMock.stub :get, "www.crystal.com/foo"
+
+        3.times do
+          HTTP::Client.get "http://www.crystal.com/foo"
+        end
+
+        stub.calls.should eq(3)
+      end
+    end
+  end
+
   # Commented so that specs run fast, but uncomment to try it (it works)
   # it "allows net connect" do
   #   WebMock.wrap do

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -1,6 +1,7 @@
 class WebMock::Stub
   @uri : URI
   @expected_headers : HTTP::Headers?
+  @calls = 0
 
   def initialize(@method : Symbol, uri)
     @uri = parse_uri(uri)
@@ -83,7 +84,12 @@ class WebMock::Stub
   end
 
   def exec
+    @calls += 1
     HTTP::Client::Response.new(@status, body: @body, headers: @headers)
+  end
+
+  def calls
+    @calls
   end
 
   private def parse_uri(uri_string)


### PR DESCRIPTION
Hi,

This PR implements a way to count how many times a stub was called, similar to ruby webmock [have_been_made](https://github.com/bblimke/webmock/blob/bf695d1dc9c541bfee69a88634b47286574e80e1/README.md#setting-expectations-in-rspec-with-a_request) matchers.

Personally, I'm using spec2 and I should be able to quickly write a matcher to test how many requests were made to that stub.

Example usage:

``` crystal
let(:stub_gcm_send_request) do
  WebMock.stub(:post, send_url).with(
    body: valid_request_body.to_json,
    headers: valid_request_headers
  ).to_return(
    body: "{}",
    headers: HTTP::Headers.new,
    status: 200
  )
end

before do
  stub_gcm_send_request
end

it "....." do
  # ... make http requests from some method
  expect(stub_gcm_send_request.calls).to eq(1)
  # or with matcher
  expect(stub_gcm_send_request).to have_been_requested
end
```
