### PR TITLE
match against to_s for MemoryIO, fix for introduction of [3406] Memor…

### DIFF
--- a/src/webmock/net_connect_not_allowed_error.cr
+++ b/src/webmock/net_connect_not_allowed_error.cr
@@ -21,7 +21,7 @@ class WebMock::NetConnectNotAllowedError < Exception
     request_uri_to_s request, io
     if request.body
       io << " with body "
-      request.body.inspect(io)
+      request.body.to_s.inspect(io)
     end
     io << " with headers "
     headers_to_s request.headers, io
@@ -45,7 +45,7 @@ class WebMock::NetConnectNotAllowedError < Exception
 
       if request.body
         io << "body: "
-        request.body.inspect(io)
+        request.body.to_s.inspect(io)
         io << ", " unless headers.empty?
       end
 

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -72,7 +72,7 @@ class WebMock::Stub
   end
 
   def matches_body?(request)
-    @expected_body ? @expected_body == request.body : true
+    @expected_body ? @expected_body == request.body.to_s : true
   end
 
   def matches_headers?(request)


### PR DESCRIPTION
This fix is for [3406](https://github.com/crystal-lang/crystal/pull/3406). Body is wrapped in a MemoryIO.  This simply exposes the body from the to_s method of MemoryIO.