### PR TITLE
Http verb string

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -348,6 +348,15 @@ describe WebMock do
     end
   end
 
+  it "takes a string for the stub method" do
+    WebMock.wrap do
+      WebMock.stub("get", "http://www.example.net")
+       response = HTTP::Client.get "http://www.example.net"
+       response.status_code.should eq(200)
+       response.body.should eq("")
+    end
+  end
+
   # Commented so that specs run fast, but uncomment to try it (it works)
   # it "allows net connect" do
   #   WebMock.wrap do

--- a/src/webmock/net_connect_not_allowed_error.cr
+++ b/src/webmock/net_connect_not_allowed_error.cr
@@ -21,7 +21,7 @@ class WebMock::NetConnectNotAllowedError < Exception
     request_uri_to_s request, io
     if request.body
       io << " with body "
-      request.body.inspect(io)
+      request.body.to_s.inspect(io)
     end
     io << " with headers "
     headers_to_s request.headers, io
@@ -45,7 +45,7 @@ class WebMock::NetConnectNotAllowedError < Exception
 
       if request.body
         io << "body: "
-        request.body.inspect(io)
+        request.body.to_s.inspect(io)
         io << ", " unless headers.empty?
       end
 

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -72,7 +72,7 @@ class WebMock::Stub
   end
 
   def matches_body?(request)
-    @expected_body ? @expected_body == request.body : true
+    @expected_body ? @expected_body == request.body.to_s : true
   end
 
   def matches_headers?(request)

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -3,7 +3,7 @@ class WebMock::Stub
   @expected_headers : HTTP::Headers?
   @calls = 0
 
-  def initialize(@method : Symbol, uri)
+  def initialize(@method : Symbol | String, uri)
     @uri = parse_uri(uri)
 
     # For to_return


### PR DESCRIPTION
I'm creating a vcr clone program that uses webmock.  I need to create stubs from a file, but since there is not string to symbol conversion, this allows creating a stub based off of String for the method. This PR simply allows a Symbol | String, matches were already against Symbol#to_s.