### PR TITLE
Change MemoryIO to IO::Memory

### DIFF
--- a/src/webmock.cr
+++ b/src/webmock.cr
@@ -36,7 +36,7 @@ module WebMock
   def self.body(request : HTTP::Request)
     body = request.body.try(&.gets_to_end)
     if body
-      request.body = MemoryIO.new(body)
+      request.body = IO::Memory.new(body)
     end
     body
   end


### PR DESCRIPTION
Fixes `MemoryIO` deprecation warning:

```
Warning: MemoryIO is deprecated and will be removed after 0.20.0, use IO::Memory instead
```

🔔 @asterite 