### PR TITLE
Allow Stub#to_return to be called with a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ response = HTTP::Client.get("http://www.example.com?count=10&page=1")
 response.status_code #=> 200
 ```
 
+### Stub requests and provide a block for the response
+
+Your block will be called and passed the `HTTP::Request`, allowing you to construct a response dynamically based upon the request.
+
+```crystal
+WebMock.stub(:post, "www.example.com/foo").to_return do |request|
+  headers = HTTP::Headers.new.merge!({ "Content-length" => request.body.to_s.length })
+  HTTP::Client::Response.new(418, body: request.body.to_s.reverse, headers: headers)
+end
+
+response = HTTP::Client.post("http://www.example.com/foo",
+                             body: "abc",
+                             headers: HTTP::Headers{"Content-Type" => "text/plain"})
+response.status_code               #=> 418
+response.body                      #=> "cba"
+response.headers["Content-length"] #=> "3"
+
+response = HTTP::Client.post("http://www.example.com/foo",
+                             body: "olleh",
+                             headers: HTTP::Headers{"Content-Type" => "text/plain"})
+response.status_code               #=> 418
+response.body                      #=> "hello"
+response.headers["Content-length"] #=> "5"
+```
+
 ### Resetting
 
 ```crystal

--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -123,6 +123,20 @@ describe WebMock do
     end
   end
 
+  it "stubs and calls block for response" do
+    WebMock.wrap do
+      WebMock.stub(:post, "www.example.com").with(body: "Hello!").to_return do |request|
+        headers = HTTP::Headers.new.merge!({ "Content-length" => "6" })
+        HTTP::Client::Response.new(418, body: request.body.to_s.reverse, headers: headers)
+      end
+
+      response = HTTP::Client.post "http://www.example.com", body: "Hello!"
+      response.body.should eq("!olleH")
+      response.status_code.should eq(418)
+      response.headers["Content-length"].should eq("6")
+    end
+  end
+
   it "stubs and returns body, with string method" do
     WebMock.wrap do
       WebMock.stub("get", "www.example.com").to_return(body: "Hello!")

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -9,7 +9,7 @@ class HTTP::Client
   private def exec_internal(request : HTTP::Request)
     request.scheme = "https" if tls?
     stub = WebMock.find_stub(request)
-    return stub.exec if stub
+    return stub.exec(request) if stub
 
     if WebMock.allows_net_connect?
       request.headers["User-agent"] ||= "Crystal"


### PR DESCRIPTION
The existing implementation of `Stub#to_return` allows yiou to provide a body, status code and set of headers statically.

This overloads the method to additionally accept a block instead which will be called with the `HTTP::Request` which will be responsible for generating the response (a `HTTP::Client::Response`).

So, for example, you can have code like this:

```crystal
WebMock.stub(:post, "www.example.com/foo").to_return do |request|
  headers = HTTP::Headers.new.merge!({ "Content-length" => request.body.to_s.length })
  HTTP::Client::Response.new(418, body: request.body.to_s.reverse, headers: headers)
end

response = HTTP::Client.post("http://www.example.com/foo",
                             body: "abc",
                             headers: HTTP::Headers{"Content-Type" => "text/plain"})
response.status_code               #=> 418
response.body                      #=> "cba"
response.headers["Content-length"] #=> "3"

response = HTTP::Client.post("http://www.example.com/foo",
                             body: "olleh",
                             headers: HTTP::Headers{"Content-Type" => "text/plain"})
response.status_code               #=> 418
response.body                      #=> "hello"
response.headers["Content-length"] #=> "5"
```

This enables interesting dynamic behaviour, and will form the foundation for work I'm planning to build a Crystal equivalent of Ruby's [vcr](https://github.com/vcr/vcr).