### PR TITLE
Added WebMock.consume_after_match

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -341,6 +341,16 @@ describe WebMock do
     end
   end
 
+  it "works with exec" do
+    WebMock.wrap do
+      WebMock.stub(:get, "http://www.example.com")
+
+      client = HTTP::Client.new "www.example.com"
+      request = HTTP::Request.new("GET", "/")
+      client.exec request
+    end
+  end
+
   describe ".calls" do
     it "returns 0 by default" do
       WebMock.wrap do

--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -278,12 +278,12 @@ describe WebMock do
       rescue ex : WebMock::NetConnectNotAllowedError
         ex.message.not_nil!.strip.should eq(
           <<-MSG
-          Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/foo?a=1 with body "Hello!" with headers {"Foo" => "Bar", "Content-Length" => "6", "Host" => "www.example.com"}
+          Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/foo?a=1 with body "Hello!" with headers {"Foo" => "Bar", "Connection" => "close", "Content-Length" => "6", "Host" => "www.example.com"}
 
           You can stub this request with the following snippet:
 
           WebMock.stub(:post, "http://www.example.com/foo?a=1").
-            with(body: "Hello!", headers: {"Foo" => "Bar"}).
+            with(body: "Hello!", headers: {"Foo" => "Bar", "Connection" => "close"}).
             to_return(body: "")
           MSG
         )
@@ -298,7 +298,7 @@ describe WebMock do
       rescue ex : WebMock::NetConnectNotAllowedError
         ex.message.not_nil!.strip.should eq(
           <<-MSG
-          Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/foo?a=1 with headers {"Content-Length" => "0", "Host" => "www.example.com"}
+          Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/foo?a=1 with headers {"Connection" => "close", "Content-Length" => "0", "Host" => "www.example.com"}
 
           You can stub this request with the following snippet:
 
@@ -317,7 +317,7 @@ describe WebMock do
       rescue ex : WebMock::NetConnectNotAllowedError
         ex.message.not_nil!.strip.should eq(
           <<-MSG
-          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com/ with headers {"Host" => "www.example.com"}
+          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com/ with headers {"Connection" => "close", "Host" => "www.example.com"}
 
           You can stub this request with the following snippet:
 

--- a/src/webmock.cr
+++ b/src/webmock.cr
@@ -4,6 +4,7 @@ module WebMock
   extend self
 
   @@allow_net_connect = false
+  @@consume_after_match = false
   @@registry = StubRegistry.new
   @@callbacks = CallbackRegistry.new
 
@@ -29,8 +30,19 @@ module WebMock
     @@allow_net_connect
   end
 
+  def consume_after_match=(@@consume_after_match)
+  end
+
+  def consume_after_match?
+    @@consume_after_match
+  end
+
   def find_stub(request : HTTP::Request)
     @@registry.find_stub(request)
+  end
+
+  def consume_stub(request : HTTP::Request)
+    @@registry.consume_stub(request)
   end
 
   def callbacks

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -8,7 +8,11 @@ end
 class HTTP::Client
   private def exec_internal(request : HTTP::Request)
     request.scheme = "https" if tls?
-    stub = WebMock.find_stub(request)
+    stub = if WebMock.consume_after_match?
+      WebMock.consume_stub(request)
+    else
+      WebMock.find_stub(request)
+    end
     return stub.exec(request) if stub
 
     if WebMock.allows_net_connect?

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -8,6 +8,7 @@ end
 class HTTP::Client
   private def exec_internal(request : HTTP::Request)
     request.scheme = "https" if tls?
+    request.headers["Host"] = host_header unless request.headers.has_key?("Host")
     stub = WebMock.find_stub(request)
     return stub.exec(request) if stub
 

--- a/src/webmock/stub_registry.cr
+++ b/src/webmock/stub_registry.cr
@@ -16,4 +16,12 @@ struct WebMock::StubRegistry
   def find_stub(request)
     @stubs.find &.matches?(request)
   end
+
+  def consume_stub(request)
+    stub = find_stub(request)
+    if stub
+      @stubs.delete(stub)
+    end
+    stub
+  end
 end


### PR DESCRIPTION
Added `WebMock.consume_after_match` and `WebMock#consume_stub` to allow WebMock to discard a stub after it's matched and used. Fixes https://github.com/manastech/webmock.cr/issues/20