### PR TITLE
Fix KeyError with missing Host in HTTP::Request

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -341,6 +341,16 @@ describe WebMock do
     end
   end
 
+  it "works with exec" do
+    WebMock.wrap do
+      WebMock.stub(:get, "http://www.example.com")
+
+      client = HTTP::Client.new "www.example.com"
+      request = HTTP::Request.new("GET", "/")
+      client.exec request
+    end
+  end
+
   describe ".calls" do
     it "returns 0 by default" do
       WebMock.wrap do

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -8,6 +8,7 @@ end
 class HTTP::Client
   private def exec_internal(request : HTTP::Request)
     request.scheme = "https" if tls?
+    request.headers["Host"] = host_header unless request.headers.has_key?("Host")
     stub = WebMock.find_stub(request)
     return stub.exec(request) if stub
 


### PR DESCRIPTION
This fixes a `KeyError: Missing hash key: HTTP::Headers::Key(@name="Host")` exception if you use `HTTP::client#exec` with a `HTTP::Request` instance that has no "Host" header set.

Fixes #5 