### PR TITLE
Run request callbacks before checking stub

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -333,7 +333,7 @@ describe WebMock do
     WebMock.wrap do
       WebMock.stub(:get, "http://www.example.com").with(query: {"foo" => "bar"})
 
-      client = HTTP::Client.new "http://www.example.com"
+      client = HTTP::Client.new "www.example.com"
       client.before_request do |request|
         request.query_params["foo"] = "bar"
       end
@@ -382,7 +382,7 @@ describe WebMock do
       WebMock.stub(:any, "http://www.example.net:80/")
       request = HTTP::Request.new("get", "/")
       request.headers["Host"] = "www.example.net:80"
-      client = HTTP::Client.new("http://www.example.net")
+      client = HTTP::Client.new("www.example.net")
       response = client.exec(request)
     end
   end

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -8,6 +8,7 @@ end
 class HTTP::Client
   private def exec_internal(request : HTTP::Request)
     request.scheme = "https" if tls?
+    run_before_request_callbacks(request)
     stub = WebMock.find_stub(request)
     return stub.exec(request) if stub
 


### PR DESCRIPTION
This fixes an incompatibility with Crystal 0.25 due to this commit:

[HTTP::Client: execute `before_request`callbacks right before writing the request](https://github.com/crystal-lang/crystal/blob/ff02d2d0426d214fa694b9c65071edbfce6b7564/src/http/client.cr)

I also fixed wrong calling conventions for `HTTP::Client.new` in the specs, because the first param is `host : String` not `url : String` like in `.get` etc.

This PR breaks compatibility with Crystal older than 0.25.0.
