### PR TITLE
add support for yielding HTTP::Client method types

### DIFF
--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -7,24 +7,37 @@ end
 
 class HTTP::Client
   private def exec_internal(request : HTTP::Request)
+    response = exec_internal(request) { |res| res }
+    response.tap do |response|
+      response.consume_body_io
+      response.headers.delete("Transfer-encoding")
+      response.headers["Content-length"] = response.body.bytesize.to_s
+    end
+  end
+
+  private def exec_internal(request : HTTP::Request, &block : Response -> T) : T forall T
     request.scheme = "https" if tls?
     request.headers["Host"] = host_header unless request.headers.has_key?("Host")
     run_before_request_callbacks(request)
 
     stub = WebMock.find_stub(request)
-    return stub.exec(request) if stub
+    return yield(stub.exec(request)) if stub
+    raise WebMock::NetConnectNotAllowedError.new(request) unless WebMock.allows_net_connect?
 
-    if WebMock.allows_net_connect?
-      request.headers["User-agent"] ||= "Crystal"
-      request.to_io(socket)
-      socket.flush
-      res = HTTP::Client::Response.from_io(socket, request.ignore_body?).tap do |response|
-        close unless response.keep_alive?
-      end
-      WebMock.callbacks.call(:after_live_request, request, res)
-      res
-    else
-      raise WebMock::NetConnectNotAllowedError.new(request)
+    request.headers["User-agent"] ||= "Crystal"
+    request.to_io(socket)
+    socket.flush
+
+    result = nil
+
+    HTTP::Client::Response.from_io(socket, request.ignore_body?) do |response|
+      result = yield(response)
+      close unless response.keep_alive?
+      WebMock.callbacks.call(:after_live_request, request, response)
     end
+
+    raise "Unexpected end of response" unless result.is_a?(T)
+
+    result
   end
 end


### PR DESCRIPTION
i.e.

``` crystal
WebMock.stub(:get, "http://www.foo.bar").to_return(body_io: IO::Memory.new("foobar"))

HTTP::Client.get("http://www.foo.bar") do |response|
  File.open("dump", "w+") do |file|
    IO.copy(response.body_io, file)
  end
end
```