### PR TITLE
Stub#matches_path? should get path from Request#resource only

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -370,44 +370,38 @@ describe WebMock do
 
   it "contains stubbing instructions on failure (with HTTP:Request and no path)" do
     WebMock.wrap do
-      begin
+      error_msg = <<-MSG
+      Real HTTP connections are disabled. Unregistered request: GET https://www.example.com with headers {"Host" => "www.example.com"}
+
+      You can stub this request with the following snippet:
+
+      WebMock.stub(:get, "https://www.example.com").
+        to_return(body: "")
+      MSG
+      expect_raises WebMock::NetConnectNotAllowedError, error_msg do
         url = "https://www.example.com"
         request = HTTP::Request.new("GET", url)
         uri = URI.parse(url)
         HTTP::Client.new(uri).exec(request)
-      rescue ex : WebMock::NetConnectNotAllowedError
-        ex.message.not_nil!.strip.should eq(
-          <<-MSG
-          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com with headers {"Host" => "www.example.com"}
-
-          You can stub this request with the following snippet:
-
-          WebMock.stub(:get, "https://www.example.com").
-            to_return(body: "")
-          MSG
-        )
       end
     end
   end
 
   it "contains stubbing instructions on failure (with HTTP:Request and path)" do
+    error_msg = <<-MSG
+    Real HTTP connections are disabled. Unregistered request: GET https://www.example.com/test with headers {"Host" => "www.example.com"}
+
+    You can stub this request with the following snippet:
+
+    WebMock.stub(:get, "https://www.example.com/test").
+      to_return(body: "")
+    MSG
     WebMock.wrap do
-      begin
+      expect_raises WebMock::NetConnectNotAllowedError, error_msg do
         url = "https://www.example.com/test"
         request = HTTP::Request.new("GET", url)
         uri = URI.parse(url)
         HTTP::Client.new(uri).exec(request)
-      rescue ex : WebMock::NetConnectNotAllowedError
-        ex.message.not_nil!.strip.should eq(
-          <<-MSG
-          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com/test with headers {"Host" => "www.example.com"}
-
-          You can stub this request with the following snippet:
-
-          WebMock.stub(:get, "https://www.example.com/test").
-            to_return(body: "")
-          MSG
-        )
       end
     end
   end

--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -368,6 +368,50 @@ describe WebMock do
     end
   end
 
+  it "contains stubbing instructions on failure (with HTTP:Request and no path)" do
+    WebMock.wrap do
+      begin
+        url = "https://www.example.com"
+        request = HTTP::Request.new("GET", url)
+        uri = URI.parse(url)
+        HTTP::Client.new(uri).exec(request)
+      rescue ex : WebMock::NetConnectNotAllowedError
+        ex.message.not_nil!.strip.should eq(
+          <<-MSG
+          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com with headers {"Host" => "www.example.com"}
+
+          You can stub this request with the following snippet:
+
+          WebMock.stub(:get, "https://www.example.com").
+            to_return(body: "")
+          MSG
+        )
+      end
+    end
+  end
+
+  it "contains stubbing instructions on failure (with HTTP:Request and path)" do
+    WebMock.wrap do
+      begin
+        url = "https://www.example.com/test"
+        request = HTTP::Request.new("GET", url)
+        uri = URI.parse(url)
+        HTTP::Client.new(uri).exec(request)
+      rescue ex : WebMock::NetConnectNotAllowedError
+        ex.message.not_nil!.strip.should eq(
+          <<-MSG
+          Real HTTP connections are disabled. Unregistered request: GET https://www.example.com/test with headers {"Host" => "www.example.com"}
+
+          You can stub this request with the following snippet:
+
+          WebMock.stub(:get, "https://www.example.com/test").
+            to_return(body: "")
+          MSG
+        )
+      end
+    end
+  end
+
   it "works with request callbacks" do
     WebMock.wrap do
       WebMock.stub(:get, "http://www.example.com").with(query: {"foo" => "bar"})

--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -67,6 +67,45 @@ describe WebMock do
     end
   end
 
+  it "works with HTTP::Request with full url as #resource" do
+    WebMock.wrap do
+      WebMock.stub :post, "https://www.example.com/test"
+
+      url = "https://www.example.com/test"
+      request = HTTP::Request.new("POST", url)
+      uri = URI.parse(url)
+      client = HTTP::Client.new(uri)
+      response = client.exec(request)
+      response.status_code.should eq(200)
+    end
+  end
+
+  it "works with HTTP::Request with full url as #resource, no path" do
+    WebMock.wrap do
+      WebMock.stub :post, "https://www.example.com"
+
+      url = "https://www.example.com"
+      request = HTTP::Request.new("POST", url)
+      uri = URI.parse(url)
+      client = HTTP::Client.new(uri)
+      response = client.exec(request)
+      response.status_code.should eq(200)
+    end
+  end
+
+  it "works with HTTP::Request with only a path" do
+    WebMock.wrap do
+      WebMock.stub :post, "https://www.example.com/test"
+
+      url = "https://www.example.com/test"
+      uri = URI.parse(url)
+      request = HTTP::Request.new("POST", uri.full_path)
+      client = HTTP::Client.new(uri)
+      response = client.exec(request)
+      response.status_code.should eq(200)
+    end
+  end
+
   it "doesn't find stub and raises" do
     expect_no_match do
       HTTP::Client.get "http://www.example.com"
@@ -126,7 +165,7 @@ describe WebMock do
   it "stubs and calls block for response" do
     WebMock.wrap do
       WebMock.stub(:post, "www.example.com").with(body: "Hello!").to_return do |request|
-        headers = HTTP::Headers.new.merge!({ "Content-length" => "6" })
+        headers = HTTP::Headers.new.merge!({"Content-length" => "6"})
         HTTP::Client::Response.new(418, body: request.body.to_s.reverse, headers: headers)
       end
 
@@ -388,7 +427,7 @@ describe WebMock do
   end
 
   # Commented so that specs run fast, but uncomment to try it (it works)
-  #it "calls callback after live request" do
+  # it "calls callback after live request" do
   #  WebMock.wrap do
   #    WebMock.callbacks.add do
   #      after_live_request do |request, response|
@@ -398,15 +437,15 @@ describe WebMock do
   #    WebMock.allow_net_connect = true
   #    HTTP::Client.get("http://www.example.net")
   #  end
-  #end
+  # end
 
-  #it "doesn't error if callback is not set" do
+  # it "doesn't error if callback is not set" do
   #  WebMock.wrap do
   #    WebMock.allow_net_connect = true
   #    client = HTTP::Client.get("http://www.example.net")
   #    client.status_code.should eq 200
   #  end
-  #end
+  # end
 
   # it "allows net connect" do
   #   WebMock.wrap do

--- a/src/webmock/net_connect_not_allowed_error.cr
+++ b/src/webmock/net_connect_not_allowed_error.cr
@@ -65,7 +65,8 @@ class WebMock::NetConnectNotAllowedError < Exception
     io << request.scheme
     io << "://"
     io << request.headers["Host"]
-    io << request.resource
+    io << request.path
+    io << "?#{request.query}" if request.query
   end
 
   private def headers_to_s(headers, io)

--- a/src/webmock/stub.cr
+++ b/src/webmock/stub.cr
@@ -68,8 +68,9 @@ class WebMock::Stub
 
     uri_query = @uri.query
 
-    request_uri = parse_uri("http://example.com#{request.resource}")
+    request_uri = parse_uri(request.resource)
     request_path = request_uri.path
+    request_path = "/" if request_path.to_s.empty?
     request_query = request_uri.query
 
     request_query = HTTP::Params.parse(request_query || "")
@@ -78,7 +79,6 @@ class WebMock::Stub
     @expected_query.try &.each do |key, value|
       uri_query.add(key.to_s, value.to_s)
     end
-
     request_path == uri_path && request_query == uri_query
   end
 


### PR DESCRIPTION
Hi,

I was having problem using `webmock` together with [crest](https://github.com/mamantoha/crest), getting errors like this:

```ruby
Unregistered request: POST https://webhooks.example.comhttps://webhooks.example.com
```

I had a look at how `crest` uses [HTTP::Request](https://github.com/mamantoha/crest/blob/master/src/crest/request.cr#L165-L190) and found that it gives the whole URL as `resource`, which is apparently allowed.

```
    request1 = HTTP::Request.new("POST", "https://www.example.com/test")
    p! request1.resource # => "https://www.example.com/test"
    request2 = HTTP::Request.new("POST", "https://www.example.com")
    p! request2.resource # => "https://www.example.com"
    request3 = HTTP::Request.new("POST", "/test")
    p! request3.resource # => "/test"
```

So, this PR adds a few specs and fixes parsing the `path` from the request, hopefully correct 😄 

Also sorry(?) for the formatting changes, I couldn't get my editor to stop doing it.