### PR TITLE
Use the most recent stub of the same url

### DIFF
--- a/spec/webmock_spec.cr
+++ b/spec/webmock_spec.cr
@@ -216,6 +216,15 @@ describe WebMock do
     end
   end
 
+  it "uses the most recently called stub of the same url" do
+    WebMock.wrap do
+      WebMock.stub(:get, "www.example.com").to_return(body: "unu")
+      WebMock.stub(:get, "www.example.com").to_return(body: "du")
+
+      HTTP::Client.get("http://www.example.com").body.should eq("du")
+    end
+  end
+
   it "stubs indefinitely" do
     WebMock.wrap do
       WebMock.stub(:get, "www.example.com").to_return(body: "unu")

--- a/src/webmock/stub_registry.cr
+++ b/src/webmock/stub_registry.cr
@@ -5,7 +5,7 @@ struct WebMock::StubRegistry
 
   def stub(method, uri)
     stub = Stub.new(method, uri)
-    @stubs << stub
+    @stubs.unshift(stub)
     stub
   end
 


### PR DESCRIPTION
Enables the use of multiple stubs being called for the same URL, and using the last called stub for the desired response.

E.g. Can have a default stub in a before block, but able to change the response in individual specs.