### PR TITLE
close body_io after callback

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: webmock
-version: 0.14.0
+version: 0.14.1
 
 crystal: ">= 0.36.0, < 2.0.0"
 

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -35,6 +35,7 @@ class HTTP::Client
     HTTP::Client::Response.from_io(io, request.ignore_body?) do |response|
       result = yield(response)
       WebMock.callbacks.call(:after_live_request, request, response)
+    ensure
       close unless response.keep_alive?
     end
 

--- a/src/webmock/core_ext.cr
+++ b/src/webmock/core_ext.cr
@@ -34,8 +34,8 @@ class HTTP::Client
 
     HTTP::Client::Response.from_io(io, request.ignore_body?) do |response|
       result = yield(response)
-      close unless response.keep_alive?
       WebMock.callbacks.call(:after_live_request, request, response)
+      close unless response.keep_alive?
     end
 
     raise "Unexpected end of response" unless result.is_a?(T)


### PR DESCRIPTION
Webmock is closing the body_io stream before it can be accessed in the `after_live_request` callback.  This PR moves that close action to after the callback call and places in `ensure` block so an exception raised in the callback doesn't block the `close`

Example use-case:  https://github.com/mwlang/binance/blob/master/spec/support/vcr.cr#L53-L79